### PR TITLE
input_kindle: fix key-event bleeding to Kindle UI

### DIFF
--- a/ffi/input_kindle.lua
+++ b/ffi/input_kindle.lua
@@ -33,7 +33,7 @@ function input.open(device)
 	if fd == -1 then
 		error("cannot open device " .. device .. ", error " .. ffi.errno())
 	end
-	ffi.C.ioctl(fd, ffi.C.EVIOCGRAB, 1)
+	ffi.C.ioctl(fd, ffi.C.EVIOCGRAB, ffi.new("uint64_t", 1))
 	evloop.register_fd(fd, input)
 end
 


### PR DESCRIPTION
Fixes issue https://github.com/hwhw/kindlevncviewer/issues/9  
The ffi.C.ioctl call for EVIOCGRAB doesn't simply take "1" as an argument, as this would be treated as "double".  
This caused the ioctl to fail and kindlevncviewer didn't get exclusive access to the key events.